### PR TITLE
Support ip override to avoid local network conflicts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,15 @@ Vagrant.configure(2) do |config|
     gemp.vm.network "private_network", ip: private_ip
     # gemp.vm.network "forwarded_port", guest: 8080, host: 8080, auto_correct: true
 
+    gemp.vm.post_up_message = <<-HEREDOC
+    Startup:
+        vagrant ssh
+        mvn clean install
+        ./run-gemp.sh
+    Web Address:
+        http://#{private_ip}:8080/gemp-swccg
+    HEREDOC
+
     # Provider-specific configuration so you can fine-tune various
     # backing providers for Vagrant. These expose provider-specific options.
     # Example for VirtualBox:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# enable overrides with env vars
+private_ip = ENV['GEMP_PRIVATE_IP'] || "192.168.50.94"
+
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
@@ -16,7 +19,8 @@ Vagrant.configure(2) do |config|
 
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
-    gemp.vm.network "private_network", ip: "192.168.50.94"
+    gemp.vm.network "private_network", ip: private_ip
+    # gemp.vm.network "forwarded_port", guest: 8080, host: 8080, auto_correct: true
 
     # Provider-specific configuration so you can fine-tune various
     # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
# Overview

When starting locally, it happens that my local network address is in the 192.168.50.x space. Thus, every time I want to start a dev env, I need to alter the Vagrantfile. Not major, but it raises the risk of an accidental commit to the Vagrantfile.

This PR shows one way to alter the IP if there is a need to use a static IP. The dev could setup an environment var locally and override the IP, likely not needed often but handy for those rare conflicts. E.g. to shift the VM to use `http://192.168.51.94:8080/gemp-swccg` instead...

```
export GEMP_PRIVATE_IP=192.168.51.94
vagrant up
```

---

Also, adds a startup message to show devs the IP, some terminals even let you click the url to make it really  easy to open the app. 

```
==> gemp: Machine 'gemp' has a post `vagrant up` message. This is a message
==> gemp: from the creator of the Vagrantfile, and not from Vagrant itself:
==> gemp:
==> gemp:     Startup:
==> gemp:         vagrant ssh
==> gemp:         mvn clean install
==> gemp:         ./run-gemp.sh
==> gemp:     Web Address:
==> gemp:         http://192.168.51.94:8080/gemp-swccg
==> gemp:
```

# Follow up thoughts

Another alternative would be to use ports. My initial smoke test to use a port forward, and set it to 8080 (with auto correct to handle conflicts if 8080 is not available) seemed to work fine. GEMP still initially booted up. A port forward may be the ideal default. This assumes there is not a reason for the static IP. The result would be to access GEMP at `http://localhost:8080/gemp-swccg`.